### PR TITLE
Front end signup page validation

### DIFF
--- a/frontend/src/components/SignupFormPage/index.js
+++ b/frontend/src/components/SignupFormPage/index.js
@@ -4,8 +4,8 @@ import { Redirect, Link } from "react-router-dom";
 import * as sessionActions from '../../store/sessionSlice';
 import "./SignupForm.css";
 
-import { Field, Form, Formik } from "formik";
-import { initialSignupValues } from "../../validations";
+import { ErrorMessage, Field, Form, Formik } from "formik";
+import { initialSignupValues, signupValidationSchema } from "../../validations";
 
 export default function SignupFormPage() {
   const dispatch = useDispatch();
@@ -25,9 +25,11 @@ export default function SignupFormPage() {
   };
 
   return (
-		<Formik 
-      initialValues={initialSignupValues}
-      onSubmit={handleFormSubmit}>
+		<Formik
+			onSubmit={handleFormSubmit}
+			initialValues={initialSignupValues}
+			validationSchema={signupValidationSchema}
+		>
 			{({ values, handleChange, handleBlur, handleSubmit }) => (
 				<Form onSubmit={handleSubmit}>
 					<label htmlFor="username">Username</label>
@@ -39,6 +41,7 @@ export default function SignupFormPage() {
 						onBlur={handleBlur}
 						value={values.username}
 					/>
+					<ErrorMessage name="username" />
 
 					<label htmlFor="email">Email</label>
 					<Field
@@ -49,6 +52,7 @@ export default function SignupFormPage() {
 						onBlur={handleBlur}
 						value={values.email}
 					/>
+					<ErrorMessage name="email" />
 
 					<label htmlFor="password">Password</label>
 					<Field
@@ -59,6 +63,7 @@ export default function SignupFormPage() {
 						onBlur={handleBlur}
 						value={values.password}
 					/>
+					<ErrorMessage name="password" />
 
 					<label htmlFor="confirmPassword">Confirm password</label>
 					<Field
@@ -69,6 +74,7 @@ export default function SignupFormPage() {
 						onBlur={handleBlur}
 						value={values.confirmPassword}
 					/>
+					<ErrorMessage name="confirmPassword" />
 
 					<button type="submit">SIGNUP</button>
 					<Link to="/login">

--- a/frontend/src/components/SignupFormPage/index.js
+++ b/frontend/src/components/SignupFormPage/index.js
@@ -5,6 +5,7 @@ import "./SignupForm.css";
 
 import { Field, Form, Formik } from "formik";
 import { initialSignupValues } from "../../validations";
+import { Link } from "react-router-dom";
 
 export default function SignupFormPage() {
   const dispatch = useDispatch();
@@ -57,8 +58,11 @@ export default function SignupFormPage() {
 						onBlur={handleBlur}
 						value={values.confirmPassword}
 					/>
-          
-          <button type='submit'>SIGNUP</button>
+
+					<button type="submit">SIGNUP</button>
+					<Link to="/login">
+						Already have an account? Login here!
+					</Link>
 				</Form>
 			)}
 		</Formik>

--- a/frontend/src/components/SignupFormPage/index.js
+++ b/frontend/src/components/SignupFormPage/index.js
@@ -54,7 +54,7 @@ export default function SignupFormPage() {
 					<Field
 						name="password"
 						id="password"
-						type="text"
+						type="password"
 						onChange={handleChange}
 						onBlur={handleBlur}
 						value={values.password}

--- a/frontend/src/components/SignupFormPage/index.js
+++ b/frontend/src/components/SignupFormPage/index.js
@@ -1,85 +1,64 @@
-import React, { useState } from "react";
+import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { Redirect } from "react-router-dom";
-import * as sessionActions from "../../store/sessionSlice";
 import "./SignupForm.css";
 
+import { Field, Form, Formik } from "formik";
+import { initialSignupValues } from "../../validations";
 
 export default function SignupFormPage() {
   const dispatch = useDispatch();
   const sessionUser = useSelector((state) => state.session.user);
-  const [email, setEmail] = useState("");
-  const [username, setUsername] = useState("");
-  const [password, setPassword] = useState("");
-  const [confirmPassword, setConfirmPassword] = useState("");
-  const [errors, setErrors] = useState([]);
-
   if (sessionUser) return <Redirect to="/" />;
 
   const handleSubmit = async (event) => {
-    event.preventDefault();
-    if (password === confirmPassword) {
-      setErrors([]);
-      return dispatch(sessionActions.signup({ email, username, password }))
-        .unwrap()
-        .catch(async (backendValidationErrors) => {
-          setErrors(backendValidationErrors)
-        });
-    }
-
-    return setErrors(['Password fields must match']); 
   };
 
   return (
-    <form onSubmit={handleSubmit}>
-      <ul>
-        {errors.map((error, idx) => {
-          return <li key={idx}>{error}</li>;
-        })}
-      </ul>
-      <div className="credentials">
-        <div>
-          <label>
-            Username
-            <input
-              type="text"
-              value={username}
-              onChange={(event) => setUsername(event.target.value)}
-              required
-            />
-          </label>
-          <label>
-            Email
-            <input
-              type="text"
-              value={email}
-              onChange={(event) => setEmail(event.target.value)}
-              required
-            />
-          </label>
-        </div>
-        <div>
-          <label>
-            Password
-            <input
-              type="pasword"
-              value={password}
-              onChange={(event) => setPassword(event.target.value)}
-              required
-            />
-          </label>
-          <label>
-            Confirm Password
-            <input
-              type="pasword"
-              value={confirmPassword}
-              onChange={(event) => setConfirmPassword(event.target.value)}
-              required
-            />
-          </label>
-        </div>
-      </div>
-      <button type="submit">Sign Up</button>
-    </form>
+		<Formik initialValues={initialSignupValues}>
+			{({ values, handleChange, handleBlur }) => (
+				<Form>
+					<label htmlFor="username">Username</label>
+					<Field
+						name="username"
+						id="username"
+						type="text"
+						onChange={handleChange}
+						onBlur={handleBlur}
+						value={values.username}
+					/>
+
+					<label htmlFor="email">Email</label>
+					<Field
+						name="email"
+						id="email"
+						type="email"
+						onChange={handleChange}
+						onBlur={handleBlur}
+						value={values.email}
+					/>
+
+					<label htmlFor="password">Password</label>
+					<Field
+						name="password"
+						id="password"
+						type="text"
+						onChange={handleChange}
+						onBlur={handleBlur}
+						value={values.password}
+					/>
+
+					<label htmlFor="confirmPassword">Confirm password</label>
+					<Field
+						name="confirmPassword"
+						id="confirmPassword"
+						type="password"
+						onChange={handleChange}
+						onBlur={handleBlur}
+						value={values.confirmPassword}
+					/>
+				</Form>
+			)}
+		</Formik>
   );
 };

--- a/frontend/src/components/SignupFormPage/index.js
+++ b/frontend/src/components/SignupFormPage/index.js
@@ -57,6 +57,8 @@ export default function SignupFormPage() {
 						onBlur={handleBlur}
 						value={values.confirmPassword}
 					/>
+          
+          <button type='submit'>SIGNUP</button>
 				</Form>
 			)}
 		</Formik>

--- a/frontend/src/components/SignupFormPage/index.js
+++ b/frontend/src/components/SignupFormPage/index.js
@@ -1,24 +1,35 @@
 import React from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { Redirect } from "react-router-dom";
+import { Redirect, Link } from "react-router-dom";
+import * as sessionActions from '../../store/sessionSlice';
 import "./SignupForm.css";
 
 import { Field, Form, Formik } from "formik";
 import { initialSignupValues } from "../../validations";
-import { Link } from "react-router-dom";
 
 export default function SignupFormPage() {
   const dispatch = useDispatch();
   const sessionUser = useSelector((state) => state.session.user);
   if (sessionUser) return <Redirect to="/" />;
 
-  const handleSubmit = async (event) => {
+  const handleFormSubmit = async (values) => {
+    const { username, email, password, confirmPassword } = values; 
+
+    if (password === confirmPassword) {
+      return dispatch(sessionActions.signup({ email, username, password }))
+        .unwrap()
+        .catch(async (backendValidationErrors) => {
+          alert(backendValidationErrors);
+        });
+	  }
   };
 
   return (
-		<Formik initialValues={initialSignupValues}>
-			{({ values, handleChange, handleBlur }) => (
-				<Form>
+		<Formik 
+      initialValues={initialSignupValues}
+      onSubmit={handleFormSubmit}>
+			{({ values, handleChange, handleBlur, handleSubmit }) => (
+				<Form onSubmit={handleSubmit}>
 					<label htmlFor="username">Username</label>
 					<Field
 						name="username"

--- a/frontend/src/validations/index.js
+++ b/frontend/src/validations/index.js
@@ -4,8 +4,8 @@ import * as yup from "yup";
 export const loginValidationSchema = yup.object().shape({
 	credential: yup
 		.string()
-		.required("Your username or email address is required."),
-	password: yup.string().required("Your password is required."),
+		.required("Your username or email address is required"),
+	password: yup.string().required("Your password is required"),
 });
 
 export const initialLoginValues = {
@@ -17,24 +17,24 @@ export const initialLoginValues = {
 export const signupValidationSchema = yup.object().shape({
 	username: yup
 		.string()
-		.min(4, "Your username must be at least 4 characters long.")
-		.max(30, "Your username must be less than 30 characters long.")
-		.required("required"),
+		.min(4, "Your username must be at least 4 characters long")
+		.max(30, "Your username must be less than 30 characters long")
+		.required("Choose a username"),
 	email: yup
 		.string()
 		.email("Your email must be a valid email.")
-		.min(3, "Your password must be between 3 and 56 characters long.")
-		.max(56, "Your password must be between 3 and 56 characters long.")
-		.required("required"),
+		.min(3, "Your password must be between 3 and 56 characters long")
+		.max(56, "Your password must be between 3 and 56 characters long")
+		.required("Your email is required"),
 	password: yup
 		.string()
-		.min(6, "Your password must be between 6 and 20 characters long.")
-		.max(20, "Your password must be between 6 and 20 characters long.")
+		.min(6, "Your password must be between 6 and 20 characters long")
+		.max(20, "Your password must be between 6 and 20 characters long")
 		.required("Your password is required"),
 	confirmPassword: yup
 		.string()
-		.oneOf([yup.ref("password"), null], "Your passwords must match.")
-		.required("Confirm your password."),
+		.oneOf([yup.ref("password"), null], "Your passwords must match")
+		.required("Confirm your password"),
 });
 
 export const initialSignupValues = {


### PR DESCRIPTION
## Description

<!-- What does this code change? Why did I choose this approach? Did I learn anything worth sharing? Reminder: This will be a publicly facing representation of your work (READ: help you land that sweet dev gig). -->

This PR implements code that adds front-end form validation to the signup screen to supplement existing back-end form validation. This provides the user with dynamic and responsive feedback well before a signup request is even attempted, leading to an improvement in user experience.

## Related Issue
Closes #3 

## Acceptance Criteria

- [x] Alert the user of signup requirements when the signup form field inputs have been touched, lose focus, and do not conform to the validation schema.


## Type of Changes
|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
| ✓   | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before
<!-- If UI feature, take provide screenshots -->
The user wasn't prompted of signup form requirements until they attempted to submit non-conforming data. 


https://github.com/jongranados/authenticate-me/assets/9102330/32a90334-514e-4b4e-8e6a-d86770584877



### After
<!-- If UI feature, take provide screenshots -->
Validation occurs in the front-end and feedback is immediately provided to the user, prompting them to address any inputs that do not conform to our validation schema.


https://github.com/jongranados/authenticate-me/assets/9102330/ecb3a05c-f0a8-4df8-9c7c-cb6390227d70

